### PR TITLE
Bugfix for compiling C++ benchmark with g++.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ plot: Test.csv
 	gnuplot -persist Plot.gplt
 	
 Test.csv:
-	g++ -ldl main.cpp -o bench
+	g++ -o bench main.cpp -ldl
 	python main.py
 		
 clean:


### PR DESCRIPTION
Default command gave me a lot of unresolved references errors:

/tmp/ccWwYuqm.o: In function `GetLibrarayFunction(std::string)':
main.cpp:(.text+0x1f): undefined reference to`dlopen'
main.cpp:(.text+0x6b): undefined reference to `dlsym'
main.cpp:(.text+0x74): undefined reference to`dlerror'
collect2: error: ld returned 1 exit status
